### PR TITLE
[service-resolver] Settings as builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ install:
 	@make docker/build
 	@make docker/cp from=/usr/local/bauhaus/composer/code to=./vendor
 
+tests:
+	@make docker/run cmd='make tests'
+
 tests/%:
 	@make docker/run cmd='make ${@}'
 
@@ -43,15 +46,19 @@ docker:
 docker/files:
 	@echo docker-compose.yaml $(if ${CI},,docker-compose.local.yaml)
 
-docker/run: options = --no-deps $(if ${CI},-T)
+docker/run: options = --rm --no-deps $(if ${CI},-T)
 docker/run:
 	@make docker cmd='run ${options} bauhaus ${cmd}'
+	@make docker/down
+
+docker/down:
+	@make docker cmd='down --remove-orphans'
 
 docker/cp:
 	@rm -rf ${to}
 	@make docker cmd='up -d'
 	@make docker cmd='cp bauhaus:${from} ${to}'
-	@make docker cmd='down --remove-orphans'
+	@make docker/down
 
 docker/%:
 	@make docker cmd='${*}'

--- a/code/Makefile
+++ b/code/Makefile
@@ -2,6 +2,7 @@ MAKEFLAGS += --silent
 .PHONY: tests
 
 tests:
+	@make tests/cs
 	@make tests/unit
 	@make tests/mutation
 

--- a/code/Makefile
+++ b/code/Makefile
@@ -8,6 +8,14 @@ tests:
 tests/cs:
 	@phpcs -ps \
 		--cache=${CACHE_DIR}/phpcs.cache
+	@deptrac \
+		--fail-on-uncovered \
+		--report-uncovered \
+		--cache-file=${CACHE_DIR}/deptrac.cache
+	@deptrac \
+		--formatter=graphviz-image \
+		--output=${REPORTS_DIR}/dep-graph.svg \
+		--cache-file=${CACHE_DIR}/deptrac.cache
 
 tests/unit:
 	@phpunit \

--- a/code/deptrac.yaml
+++ b/code/deptrac.yaml
@@ -2,9 +2,9 @@ deptrac:
   ignore_uncovered_internal_classes: true # ignore dependency to internal php classes
 
   paths:
-    - ./src
+    - ./packages
     - ./tests
-    - ./../vendor/psr
+    - ../composer/code/psr
   exclude_files: ~
 
   ruleset:
@@ -16,13 +16,13 @@ deptrac:
   layers:
     - name: ServiceResolver
       collectors:
-      - { type: directory, value: ./src/service-resolver/public/ }
-      - { type: directory, value: ./src/service-resolver/private/, private: true }
+      - { type: directory, value: ./packages/service-resolver/public/ }
+      - { type: directory, value: ./packages/service-resolver/private/, private: true }
 
     - name: TypeUri
       collectors:
-      - { type: directory, value: ./src/uri/public/ }
-      - { type: directory, value: ./src/uri/private/, private: true }
+      - { type: directory, value: ./packages/type-uri/public/ }
+      - { type: directory, value: ./packages/type-uri/private/, private: true }
 
     - name: TestServiceResolver
       collectors:
@@ -31,11 +31,11 @@ deptrac:
 
     - name: TestTypeUri
       collectors:
-      - { type: directory, value: ./tests/Types/Uri/ }
+      - { type: directory, value: ./tests/Types/UriTest.php }
 
     - name: PSR-11
       collectors:
-      - { type: directory, value: ../vendor/psr/container/ }
+      - { type: directory, value: ../composer/code/psr/container/ }
 
     - name: PhpUnit
       collectors:

--- a/code/packages/service-resolver/LICENSE
+++ b/code/packages/service-resolver/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Bauhaus PHP
+Copyright (c) 2023 Bauhaus PHP
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/code/packages/service-resolver/README.md
+++ b/code/packages/service-resolver/README.md
@@ -31,10 +31,9 @@ $ composer require bauhaus/service-resolver
 ```php
 <?php
 
-use Bauhaus\ServiceResolver;
 use Bauhaus\ServiceResolverSettings;
 
-$settings = ServiceResolverSettings::new()
+$psrContainer = ServiceResolverSettings::new()
     ->withDefintionFiles(
         'path/file-1.php',
         'path/file-2.php',
@@ -46,11 +45,10 @@ $settings = ServiceResolverSettings::new()
     ->withDiscoverableNamespaces(
         'App\\Namespace1',
         'App\\Namespace2',
-    );
+    )
+    ->build();
 
-$serviceResolver = ServiceResolver::build($settings);
-
-$serviceResolver->has($serviceId);
-$serviceResolver->get($serviceId);
+$psrContainer->has($serviceId);
+$psrContainer->get($serviceId);
 ```
 

--- a/code/packages/service-resolver/composer.json
+++ b/code/packages/service-resolver/composer.json
@@ -20,7 +20,7 @@
     },
 
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "psr/container": "^2.0.2"
     }
 }

--- a/code/packages/service-resolver/private/CircularDependencyDetector/CircularDependencyDetector.php
+++ b/code/packages/service-resolver/private/CircularDependencyDetector/CircularDependencyDetector.php
@@ -9,10 +9,10 @@ use Bauhaus\ServiceResolver\Locator;
 /**
  * @internal
  */
-final class CircularDependencyDetector implements Locator
+final readonly class CircularDependencyDetector implements Locator
 {
     public function __construct(
-        private readonly Locator $actualLocator,
+        private Locator $actualLocator,
     ) {
     }
 

--- a/code/packages/service-resolver/private/Container/DefinitionFile.php
+++ b/code/packages/service-resolver/private/Container/DefinitionFile.php
@@ -7,10 +7,10 @@ use InvalidArgumentException;
 /**
  * @internal
  */
-final class DefinitionFile
+final readonly class DefinitionFile
 {
     public function __construct(
-        private readonly string $path
+        private string $path
     ) {
         $this->assertFileExist();
     }

--- a/code/packages/service-resolver/private/Container/ProvidedServiceContainer.php
+++ b/code/packages/service-resolver/private/Container/ProvidedServiceContainer.php
@@ -9,10 +9,10 @@ use Bauhaus\ServiceResolverSettings;
 /**
  * @internal
  */
-final class ProvidedServiceContainer implements Locator
+final readonly class ProvidedServiceContainer implements Locator
 {
     private function __construct(
-        /** @var ProvidedService[] */ private readonly array $services,
+        /** @var ProvidedService[] */ private array $services,
     ) {
     }
 

--- a/code/packages/service-resolver/private/Discoverer/DependencyLoader/DependenciesLoader.php
+++ b/code/packages/service-resolver/private/Discoverer/DependencyLoader/DependenciesLoader.php
@@ -10,9 +10,9 @@ use ReflectionParameter as RParam;
 /**
  * @internal
  */
-final class DependenciesLoader
+final readonly class DependenciesLoader
 {
-    /** @var LoadableDependency[] */ private readonly array $dependencies;
+    /** @var LoadableDependency[] */ private array $dependencies;
 
     private function __construct(RParam ...$rParams)
     {

--- a/code/packages/service-resolver/private/Discoverer/DependencyLoader/LoadableDependency.php
+++ b/code/packages/service-resolver/private/Discoverer/DependencyLoader/LoadableDependency.php
@@ -10,12 +10,12 @@ use ReflectionParameter as RParam;
 /**
  * @internal
  */
-final class LoadableDependency
+final readonly class LoadableDependency
 {
     private const PRIMITIVE_TYPES = ['bool', 'int', 'float', 'string', 'array'];
 
     public function __construct(
-        private readonly RParam $rParam
+        private RParam $rParam
     ) {
         $this->assertIsLoadable();
     }

--- a/code/packages/service-resolver/private/Identifier.php
+++ b/code/packages/service-resolver/private/Identifier.php
@@ -7,10 +7,10 @@ use ReflectionClass as RClass;
 /**
  * @internal
  */
-final class Identifier
+final readonly class Identifier
 {
     public function __construct(
-        private readonly string $value,
+        private string $value,
     ) {
     }
 

--- a/code/packages/service-resolver/private/SelfPsrContainerLocator/SelfPsrContainerDetector.php
+++ b/code/packages/service-resolver/private/SelfPsrContainerLocator/SelfPsrContainerDetector.php
@@ -10,10 +10,10 @@ use Psr\Container\ContainerInterface as PsrContainer;
 /**
  * @internal
  */
-final class SelfPsrContainerDetector implements Locator
+final readonly class SelfPsrContainerDetector implements Locator
 {
     public function __construct(
-        private readonly Locator $actualLocator,
+        private Locator $actualLocator,
     ) {
     }
 

--- a/code/packages/service-resolver/private/SelfPsrContainerLocator/SelfPsrContainerReturner.php
+++ b/code/packages/service-resolver/private/SelfPsrContainerLocator/SelfPsrContainerReturner.php
@@ -8,7 +8,7 @@ use Psr\Container\ContainerInterface as PsrContainer;
 /**
  * @internal
  */
-final class SelfPsrContainerReturner implements Definition
+final readonly class SelfPsrContainerReturner implements Definition
 {
     public function load(PsrContainer $psrContainer): object
     {

--- a/code/packages/service-resolver/private/ServiceResolver.php
+++ b/code/packages/service-resolver/private/ServiceResolver.php
@@ -1,20 +1,19 @@
 <?php
 
-namespace Bauhaus;
+namespace Bauhaus\ServiceResolver;
 
 use Bauhaus\ServiceResolver\CircularDependencyDetector\CircularDependencyDetector;
 use Bauhaus\ServiceResolver\Container\ProvidedServiceContainer;
-use Bauhaus\ServiceResolver\Definition;
-use Bauhaus\ServiceResolver\DefinitionLoadingError;
-use Bauhaus\ServiceResolver\DefinitionNotFound;
 use Bauhaus\ServiceResolver\Discoverer\Discoverer;
-use Bauhaus\ServiceResolver\Identifier;
-use Bauhaus\ServiceResolver\Locator;
 use Bauhaus\ServiceResolver\MemoryCache\MemoryCache;
 use Bauhaus\ServiceResolver\SelfPsrContainerLocator\SelfPsrContainerDetector;
+use Bauhaus\ServiceResolverSettings;
 use Psr\Container\ContainerInterface as PsrContainer;
 use Throwable;
 
+/**
+ * @internal
+ */
 final class ServiceResolver implements PsrContainer
 {
     private function __construct(

--- a/code/packages/service-resolver/private/ServiceResolver.php
+++ b/code/packages/service-resolver/private/ServiceResolver.php
@@ -14,10 +14,10 @@ use Throwable;
 /**
  * @internal
  */
-final class ServiceResolver implements PsrContainer
+final readonly class ServiceResolver implements PsrContainer
 {
     private function __construct(
-        private readonly Locator $locator,
+        private Locator $locator,
     ) {
     }
 

--- a/code/packages/service-resolver/public/ServiceResolverSettings.php
+++ b/code/packages/service-resolver/public/ServiceResolverSettings.php
@@ -2,12 +2,14 @@
 
 namespace Bauhaus;
 
-final class ServiceResolverSettings
+use Bauhaus\ServiceResolver\ServiceResolver;
+
+final readonly class ServiceResolverSettings
 {
     private function __construct(
-        public readonly array $services,
-        public readonly array $definitionFiles,
-        public readonly array $discoverableNamespaces,
+        public array $services,
+        public array $definitionFiles,
+        public array $discoverableNamespaces,
     ) {
     }
 

--- a/code/packages/service-resolver/public/ServiceResolverSettings.php
+++ b/code/packages/service-resolver/public/ServiceResolverSettings.php
@@ -39,4 +39,9 @@ final class ServiceResolverSettings
     {
         return new self($this->services, $this->definitionFiles, $discoverableNamespaces);
     }
+
+    public function build(): ServiceResolver
+    {
+        return ServiceResolver::build($this);
+    }
 }

--- a/code/tests/ServiceResolver/GetTest.php
+++ b/code/tests/ServiceResolver/GetTest.php
@@ -30,14 +30,11 @@ use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithOneDependency;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithoutDependencyA;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithoutDependencyB;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\Unresolvable;
-use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface as PsrNotFoundException;
 use Psr\Container\ContainerExceptionInterface as PsrContainerException;
 
-class GetTest extends TestCase
+class GetTest extends ServiceResolverTestCase
 {
-    use ServiceResolverSetup;
-
     public function idsWithExpectedClasses(): array
     {
         return [

--- a/code/tests/ServiceResolver/HaveTest.php
+++ b/code/tests/ServiceResolver/HaveTest.php
@@ -28,12 +28,9 @@ use Bauhaus\Tests\ServiceResolver\Doubles\DiscoverB\SubdependencyOnScalar2;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithOneDependency;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithoutDependencyA;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\Unresolvable;
-use PHPUnit\Framework\TestCase;
 
-class HaveTest extends TestCase
+class HaveTest extends ServiceResolverTestCase
 {
-    use ServiceResolverSetup;
-
     public function idsWithDefinition(): array
     {
         return [

--- a/code/tests/ServiceResolver/HaveTest.php
+++ b/code/tests/ServiceResolver/HaveTest.php
@@ -81,7 +81,7 @@ class HaveTest extends ServiceResolverTestCase
     {
         return [
             'non existing id' => ['non-existing-id'],
-            'out of any discoverable namespace #1' => [\stdClass::class],
+            'out of any discoverable namespace #1' => [\DateTime::class],
             'out of any discoverable namespace #2' => [\stdClass::class],
             'out of any discoverable namespace #3' => [Unresolvable::class],
             'interface among discoverable namespace' => [InterfaceInADiscoverableNamespace::class],

--- a/code/tests/ServiceResolver/ProvidedServicesValidationTest.php
+++ b/code/tests/ServiceResolver/ProvidedServicesValidationTest.php
@@ -2,8 +2,8 @@
 
 namespace Bauhaus\Tests\ServiceResolver;
 
-use Bauhaus\ServiceResolver;
 use Bauhaus\ServiceResolverSettings;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ProvidedServicesValidationTest extends TestCase
@@ -16,10 +16,10 @@ class ProvidedServicesValidationTest extends TestCase
         $settings = ServiceResolverSettings::new()
             ->withDefinitionFiles('invalid-file-path');
 
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Definition file does not exist: invalid-file-path');
 
-        ServiceResolver::build($settings);
+        $settings->build();
     }
 
     /**
@@ -31,10 +31,10 @@ class ProvidedServicesValidationTest extends TestCase
         $settings = ServiceResolverSettings::new()
             ->withDefinitionFiles($filePath);
 
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage("Definition file must return array: {$filePath}");
 
-        ServiceResolver::build($settings);
+        $settings->build();
     }
 
     /**
@@ -45,9 +45,9 @@ class ProvidedServicesValidationTest extends TestCase
         $settings = ServiceResolverSettings::new()
             ->withDefinitionFiles(__DIR__ . '/Doubles/definitions-file-invalid-definition.php');
 
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage("Invalid service provided");
 
-        ServiceResolver::build($settings);
+        $settings->build();
     }
 }

--- a/code/tests/ServiceResolver/ServiceResolverTestCase.php
+++ b/code/tests/ServiceResolver/ServiceResolverTestCase.php
@@ -2,31 +2,23 @@
 
 namespace Bauhaus\Tests\ServiceResolver;
 
-use Bauhaus\ServiceResolver;
 use Bauhaus\ServiceResolverSettings;
 use Bauhaus\Tests\ServiceResolver\Doubles\DiscoverA\DiscoverableA1;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithoutDependencyA;
 use Bauhaus\Tests\ServiceResolver\Doubles\NotDiscover\ServiceWithoutDependencyB;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface as PsrContainer;
 
-trait ServiceResolverSetup
+abstract class ServiceResolverTestCase extends TestCase
 {
-    protected readonly ServiceResolver $resolver;
-    private readonly ServiceResolverSettings $settings;
+    protected readonly PsrContainer $resolver;
 
     /**
      * @before
      */
     public function setUpServiceResolver(): void
     {
-        $this->resolver = ServiceResolver::build($this->settings);
-    }
-
-    /**
-     * @before
-     */
-    public function setUpSettings(): void
-    {
-        $this->settings = ServiceResolverSettings::new()
+        $this->resolver = ServiceResolverSettings::new()
             ->withServices([
                 'callable' => fn () => new ServiceWithoutDependencyA(),
                 'concrete-object' => new ServiceWithoutDependencyB(),
@@ -42,6 +34,7 @@ trait ServiceResolverSetup
             ->withDiscoverableNamespaces(
                 'Bauhaus\\Tests\\ServiceResolver\\Doubles\\DiscoverA',
                 'Bauhaus\\Tests\\ServiceResolver\\Doubles\\DiscoverB',
-            );
+            )
+            ->build();
     }
 }

--- a/code/tests/Types/UriTest.php
+++ b/code/tests/Types/UriTest.php
@@ -3,7 +3,6 @@
 namespace Bauhaus\Tests\Types;
 
 use InvalidArgumentException;
-use Bauhaus\ServiceResolverSettings;
 use PHPUnit\Framework\TestCase;
 use Bauhaus\Types\Uri;
 
@@ -113,7 +112,6 @@ class UriTest extends TestCase
      */
     public function parseUriProperly(string $uri, Uri $expected): void
     {
-        ServiceResolverSettings::new()->withServices([]);
         $uri = Uri::fromString($uri);
 
         self::assertEquals($expected, $uri);

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -2,6 +2,7 @@ version: '3.9'
 
 services:
   bauhaus:
+    command: ['tail', '-f', '/dev/null']
     volumes:
     - ./code:/usr/local/bauhaus/code
     - ./phars:/usr/local/bauhaus/phars


### PR DESCRIPTION
This PR turns service resolver settings into a service resolver builder:

```php
$psrContainer = Bauhaus\ServiceResolverSettings::new(
    ->withServices(...)
    ->withDefinitionFiles(...)
    ->build();
```